### PR TITLE
Fix issue badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following channels are available for discussions, feedback, and support requ
 
 | Type                     | Channel                                                |
 | ------------------------ | ------------------------------------------------------ |
-| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-kotlin-jfn/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-kotlin-jfn/question.svg?style=flat-square"></a> </a>   |
+| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-kotlin-jfn/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-kotlin-jfn?style=flat-square"></a> |
 | **Other requests**    | <a href="mailto:corona-warn-app.opensource@sap.com" title="Email CWA Team"><img src="https://img.shields.io/badge/email-CWA%20team-green?logo=mail.ru&style=flat-square&logoColor=white"></a> |
 
 ## How to contribute


### PR DESCRIPTION
- Change badge to show count of all issues, not only issues with label "question".

- This is the equivalent to PR https://github.com/corona-warn-app/cwa-app-ccl/pull/97 in the https://github.com/corona-warn-app/cwa-app-ccl repository.

- In this repository the problem was not yet noticeable since there have been 0 issues opened so far.

README will then show the following:

| Type                     | Channel                                                |
| ------------------------ | ------------------------------------------------------ |
| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-kotlin-jfn/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-kotlin-jfn?style=flat-square"></a> </a>   |
