### PR TITLE
chore: support common functions in test cases

### DIFF
--- a/src/test/kotlin/CommonTestCaseProvider.kt
+++ b/src/test/kotlin/CommonTestCaseProvider.kt
@@ -13,16 +13,15 @@ class CommonTestCaseProvider : ArgumentsProvider {
         val testsFile = javaClass.classLoader.getResource("jfn-common-test-cases.gen.json")
         val tree = ObjectMapper().readTree(testsFile)
         val testCases = tree.get("testCases") as ArrayNode
+        val commonFunctions = tree.get("commonFunctions")
 
-        testCases.forEachIndexed { index, it ->
-            val testCase = it as ObjectNode
-            if (tree.has("commonFunctions")) {
-                val commonFunctions = tree.get("commonFunctions") as ArrayNode
-                testCase.set<ArrayNode>("functions", commonFunctions)
+        return testCases.map { case ->
+            val newCase = if (commonFunctions != null) {
+                (case as ObjectNode).set<ArrayNode>("functions", commonFunctions)
+            } else {
+                case
             }
-            testCases.set(index, testCase)
-        }
-
-        return testCases.map { Arguments.of(Named.of(it.get("title").textValue(), it)) }.stream()
+            Arguments.of(Named.of(newCase.get("title").textValue(), newCase))
+        }.stream()
     }
 }

--- a/src/test/kotlin/CommonTestCaseProvider.kt
+++ b/src/test/kotlin/CommonTestCaseProvider.kt
@@ -1,5 +1,6 @@
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.provider.Arguments
@@ -12,6 +13,16 @@ class CommonTestCaseProvider : ArgumentsProvider {
         val testsFile = javaClass.classLoader.getResource("jfn-common-test-cases.gen.json")
         val tree = ObjectMapper().readTree(testsFile)
         val testCases = tree.get("testCases") as ArrayNode
+
+        testCases.forEachIndexed { index, it ->
+            val testCase = it as ObjectNode
+            if (tree.has("commonFunctions")) {
+                val commonFunctions = tree.get("commonFunctions") as ArrayNode
+                testCase.set<ArrayNode>("functions", commonFunctions)
+            }
+            testCases.set(index, testCase)
+        }
+
         return testCases.map { Arguments.of(Named.of(it.get("title").textValue(), it)) }.stream()
     }
 }


### PR DESCRIPTION
if a file with shared test cases such as `jfn-common-test-cases.json` contains a top-level property `commonFunctions`, it is registered as functions to each test case in that file. This has the potentially to significantly reduce the file size of shared test cases.

This allows to reduce the file size of the CCL integration tests from [cwa-app-ccl](https://github.com/corona-warn-app/cwa-app-ccl) from >80M to ~6M and as a result, on my local machine, the test suite seems to complete a lot faster.

For iOS, see https://github.com/corona-warn-app/json-functions-swift/pull/13